### PR TITLE
workflow: automate build and artifact release

### DIFF
--- a/.github/workflows/build_and_release.yaml
+++ b/.github/workflows/build_and_release.yaml
@@ -1,0 +1,62 @@
+name: Build and Optionally Update Release
+
+on:
+  push:
+    branches:
+      - main
+  release:
+    types:
+      - published
+  pull_request:
+    branches:
+      - main
+    types:
+      - synchronize
+      - opened
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # don't stop other matrix steps if one fails
+      matrix: 
+        os: 
+          - linux
+          - darwin
+          - windows
+        arch:
+          - arm64
+          - amd64
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.19.0'
+      - run: go version # check if PATH is ok or not;
+      - run: go build -o rocketchat-cli-${{ matrix.os }}.${{ matrix.arch }}
+        env:
+          GOOS: ${{ matrix.os }}
+          GOARCH: ${{ matrix.arch }}
+      - id: list-files
+        if: ${{ always() }}
+        run: |
+          files_to_add="$(command ls -1 | grep -E '^rocketchat-cli-' | xargs | tr ' ' ',')"
+          echo "files to add: $files_to_add"
+          echo "files=$files_to_add" >> $GITHUB_OUTPUT
+      - if: ${{ github.event_name == 'release' && steps.list-files.outputs.files == '' }} # nothing was built
+        uses: 'irongut/EditRelease@v1.2.0'
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          id: ${{ github.event.release.id }}
+          draft: true # convert this to draft
+      - if: ${{ github.event_name == 'release' && steps.list-files.outputs.files != '' }} # at least something was built
+        uses: 'irongut/EditRelease@v1.2.0'
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          id: ${{ github.event.release.id }}
+          files: ${{ steps.list-files.outputs.files }}
+

--- a/.github/workflows/build_and_release.yaml
+++ b/.github/workflows/build_and_release.yaml
@@ -19,9 +19,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-and-release:
+    continue-on-error: true
     runs-on: ubuntu-latest
     strategy:
+      # max-parallel: 2
       fail-fast: false # don't stop other matrix steps if one fails
       matrix: 
         os: 
@@ -41,22 +43,19 @@ jobs:
         env:
           GOOS: ${{ matrix.os }}
           GOARCH: ${{ matrix.arch }}
-      - id: list-files
-        if: ${{ always() }}
-        run: |
-          files_to_add="$(command ls -1 | grep -E '^rocketchat-cli-' | xargs | tr ' ' ',')"
-          echo "files to add: $files_to_add"
-          echo "files=$files_to_add" >> $GITHUB_OUTPUT
-      - if: ${{ github.event_name == 'release' && steps.list-files.outputs.files == '' }} # nothing was built
-        uses: 'irongut/EditRelease@v1.2.0'
+      - if: ${{ success() && github.event_name == 'release' }} 
+        uses: 'softprops/action-gh-release@v1'
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          id: ${{ github.event.release.id }}
-          draft: true # convert this to draft
-      - if: ${{ github.event_name == 'release' && steps.list-files.outputs.files != '' }} # at least something was built
-        uses: 'irongut/EditRelease@v1.2.0'
+          files: rocketchat-cli-${{ matrix.os }}.${{ matrix.arch }}
+
+  convert-to-draft-if-failed:
+    if: ${{ github.event_name == 'release' }}
+    runs-on: ubuntu-latest
+    needs: 
+      - build-and-release
+    steps:
+      - if: ${{ needs.build-and-release.result != 'success' && needs.build-and-release.result != 'skipped' }}
+        uses: 'softprops/action-gh-release@v1'
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          id: ${{ github.event.release.id }}
-          files: ${{ steps.list-files.outputs.files }}
+          draft: true
 


### PR DESCRIPTION
- create a release with a tag (version number) on github
- the workflow will build binaries for linux, mac and windows (both arm64 and amd64)
- add those binaries to the release
- if builds fail, the release gets converted to draft